### PR TITLE
Centralize Test Coverage Report Source

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,17 +36,12 @@ build_script:
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
   - conda config --set always_yes yes
   - conda update conda
-  - conda install coverage setuptools numpy
+  - conda install setuptools numpy
   - python setup.py build
 
 test_script:
   - python -c "import sys; print(sys.version)"
   - cd Tests
   - cp biosql.ini.appveyor biosql.ini
-  - coverage run run_tests.py --offline
-  - coverage xml
+  - python run_tests.py --offline
   - cd ..
-
-after_test:
-  - conda install -c conda-forge codecov
-  - codecov --file Tests/coverage.xml -X pycov -X gcov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,4 +51,4 @@ jobs:
             echo "Tests run"
             coverage xml
       - codecov/upload:
-        file: biopython-*/Tests/coverage.xml
+          file: biopython-*/Tests/coverage.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@
 
 version: 2.1
 orbs:
-  codecov: codecov/codecov@1.0.2
+  codecov: codecov/codecov@3.1.1
 jobs:
   build:
     docker:
@@ -51,4 +51,4 @@ jobs:
             echo "Tests run"
             coverage xml
       - codecov/upload:
-          file: biopython-*/Tests/coverage.xml
+        file: biopython-*/Tests/coverage.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@
 
 version: 2.1
 orbs:
-  codecov: codecov/codecov@3.1.1
+  codecov: codecov/codecov@1.0.2
 jobs:
   build:
     docker:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,9 +202,7 @@ jobs:
     - name: Run test suite and get coverage
       run: |
         cd Tests
-        rm -rf coverage.xml
-        coverage run run_tests.py --offline
-        coverage xml
+        python run_tests.py --offline
       shell: bash
 
   test_macos:


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Addresses #3752

In this PR, I upgrade the codecov orb, and use _**one**_ test run to generate the coverage report. This seems to have fixed the allegedly random variations in coverage. I tested this by creating several PRs that randomly removed a file in the `Tests` directory, and then seeing if identical PRs would result in the same coverage report; they do.

There is one concern. I cannot tell what the difference between CirlceCI, GHA, and AppVeyor tests are. They are all run with the `--offline` flag, so the same code paths should be used in each. There is nothing to indicate that the tests run in AppVeyor implement different code paths than those in GitHub Actions or CircleCI for example. Perhaps the AppVeyor tests RDBMSs that CircleCI doesn't, but this is not something codecov would be able to detect or report on.

Please let me know if you have any questions, notes, criticisms, requests, or anything else.
